### PR TITLE
added require for clojure.java.shell

### DIFF
--- a/src/scicloj/tempfiles/api.clj
+++ b/src/scicloj/tempfiles/api.clj
@@ -1,6 +1,7 @@
 (ns scicloj.tempfiles.api
   (:require [babashka.fs :as fs]
             [clojure.java.io :as io]
+            [clojure.java.shell]
             [clojure.string :as string])
   (:import [java.io File]
            [java.nio.file Files Path Paths]


### PR DESCRIPTION
I got exceptions from noj:
```
syntax error (ClassNotFoundException) compiling at (scicloj/tempfiles/api.clj:77:7).
clojure.java.shell
```

(not when using noj from repl, but when using via `clj -e "....."`)